### PR TITLE
Minor suggestion: Use an R file to demonstrate source()

### DIFF
--- a/scripts/2-script.R
+++ b/scripts/2-script.R
@@ -418,7 +418,7 @@ is.element()
 
 # Commands can be entered from outside the GUI
 
-source("test.txt")        #TRY: create this file and run!
+source("test.R")        #TRY: create this file and run!
 
 
 


### PR DESCRIPTION
The purpose of `source()` might be clearer if the demo points to an R file, rather than a text file.
